### PR TITLE
Resolves Issue #19

### DIFF
--- a/oxipayprestashop/controllers/front/confirmation.php
+++ b/oxipayprestashop/controllers/front/confirmation.php
@@ -114,7 +114,9 @@ class OxipayprestashopConfirmationModuleFrontController extends ModuleFrontContr
             /**
             * An error occured and is shown on a new page.
             */
-            $this->errors[] = $this->module->l('An error occured. Please contact the merchant to have more information.');
+            $this->errors[] = $this->module->l('Payment has been declined by provider Oxipay');
+            $link = $this->context->link->getPageLink('order', true, NULL, "step=3");
+            $this->context->smarty->assign('checkout_link', $link);
             return $this->setTemplate('error.tpl');
         }
     }

--- a/oxipayprestashop/views/templates/front/error.tpl
+++ b/oxipayprestashop/views/templates/front/error.tpl
@@ -25,9 +25,11 @@
 
 <div>
 	<h3>{l s='An error occurred' mod='oxipayprestashop'}:</h3>
+	<br />
 	<ul class="alert alert-danger">
 		{foreach from=$errors item='error'}
 			<li>{$error|escape:'htmlall':'UTF-8'}.</li>
 		{/foreach}
 	</ul>
+	<a href="{$checkout_link}">Go back to the order checkout page</a>
 </div>


### PR DESCRIPTION
After clicking on the "RETURN TO CART" link in the Oxipay's payment declination page, the user gets redirected to this page, which shows the "Payment has been declined by provider Oxipay" error, followed by a link to the order's page.
